### PR TITLE
Add acl package to have setfacl available

### DIFF
--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -11,6 +11,7 @@
     - distgen
     - libseccomp-devel
     - postfix
+    - acl
 
 - name: Install basic tools for CentOS 7
   package:


### PR DESCRIPTION
This seems to be the reason why fedora test for postgresql fails:
https://github.com/sclorg/container-common-scripts/pull/245
