### PR TITLE
Fixes: #57 Install docker on CentOS7 and podman on the rest.

### DIFF
--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -4,8 +4,6 @@
     name: "{{ item }}"
     state: latest
   with_items:
-    - podman
-    - podman-docker
     - perl
     - git
     - make
@@ -13,12 +11,24 @@
     - postfix
     - acl
 
+- name: Install podman and podman-docker for CentOS Streams and Fedora
+  package:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - podman
+    - podman-docker
+  when: releasever > 7
+
 - name: Install basic tools for CentOS 7
   package:
     name: "{{ item }}"
     state: latest
   with_items:
     - rsync
+    - docker
+    - docker-client
+    - docker-common
     - centos-release-scl-rh
     - groff-base
     - centos-release-openshift-origin

--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -20,6 +20,15 @@
     - podman-docker
   when: releasever > 7
 
+- name: Uninstall podman and podman-docker from CentOS 7
+  package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - podman
+    - podman-docker
+  when: releasever == 7
+
 - name: Install basic tools for CentOS 7
   package:
     name: "{{ item }}"

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -7,8 +7,6 @@
   vars:
     os_test: "{{ lookup('env', 'OS') }}"
     package_names_all:
-      - podman-docker
-      - podman
       - git
       - make
       - ansible
@@ -24,14 +22,23 @@
       - python3
       - golang-github-cpuguy83-go-md2man
       - mailx
+      - docker
+      - docker-client
+      - docker-common
     package_names_c8s:
+      - podman-docker
+      - podman
       - libseccomp-devel
       - golang-github-cpuguy83-md2man
       - mailx
     package_names_c9s:
+      - podman-docker
+      - podman
       - golang-github-cpuguy83-md2man
       - s-nail
     package_names_fedora:
+      - podman-docker
+      - podman
       - acl
       - libseccomp-devel
       - openssl


### PR DESCRIPTION
This pull request installs docker, docker-client, and docker-common on CentOS 7 host. ONLY.

The rest hosts installs podman, and podman-docker.

Closes: #57