### PR TITLE
Let's add capabilities to /etc/containers/containers.conf

### DIFF
--- a/roles/services/files/containers.conf
+++ b/roles/services/files/containers.conf
@@ -1,0 +1,30 @@
+# The default configuration of containers.conf file
+# on Fedora 37 is either commented of allowed and looks like
+#  default_capabilities = [
+#   "CHOWN",
+#   "DAC_OVERRIDE",
+#   "FOWNER",
+#   "FSETID",
+#   "KILL",
+#   "NET_BIND_SERVICE",
+#   "SETFCAP",
+#   "SETGID",
+#   "SETPCAP",
+#   "SETUID",
+#   "SYS_CHROOT"
+# ]
+
+[containers]
+default_capabilities = [
+  "SYS_CHROOT",
+  "CHOWN",
+  "DAC_OVERRIDE",
+  "FOWNER",
+#  "FSETID",
+#  "KILL",
+#  "NET_BIND_SERVICE",
+  "SETFCAP",
+#  "SETGID",
+#  "SETPCAP",
+#  "SETUID",
+]

--- a/roles/services/tasks/main.yml
+++ b/roles/services/tasks/main.yml
@@ -10,6 +10,23 @@
   with_items:
     - postfix
 
+- block:
+  - name: Create directory /etc/containers
+    file:
+      path: /etc/containers
+      state: directory
+      owner: root
+      group: root
+
+  - name: files/containers.conf file to /etc/containers/containers.conf
+    copy:
+      src: "files/containers.conf"
+      dest: "/etc/containers/containers.conf"
+      owner: root
+      group: root
+      mode: 0644
+  when: releasever > 30
+
 - name: Run the docker service
   service: state=started name="{{ item }}" enabled=yes
   with_items:

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -45,6 +45,7 @@
       - s-nail
     files_to_check_fedora:
       - /etc/containers/nodocker
+      - /etc/containers/containers.conf
     files_to_check_centos7:
       - /etc/rhsm/ca/redhat-uep.pem
       - /etc/sysconfig/docker


### PR DESCRIPTION
Let's add capabilities to /etc/containers/containers.conf 

https://bugzilla.redhat.com/show_bug.cgi?id=2170568

The result e.g. from httpd-container is:
```bash
make[1]: Entering directory '/home/phracek/httpd-container'
VERSION="2.4" SKIP_SQUASH=1 OS=fedora CLEAN_AFTER= DOCKER_BUILD_CONTEXT=.. OPENSHIFT_NAMESPACES="" CUSTOM_REPO="" REGISTRY="quay.io/" /usr/bin/env bash common/build.sh
-> Version 2.4: building image from 'Dockerfile.fedora' ...
-> Pulling image quay.io/fedora/s2i-core:35 before building image from Dockerfile.fedora.
Trying to pull quay.io/fedora/s2i-core:35...
Getting image source signatures
Copying blob cfd36ec3bc08 done
Copying blob 9c6cc3463716 done
Copying config 3c589d2089 done
Writing manifest to image destination
Storing signatures
-> building using docker build  --label io.openshift.builder-version="8b02dbc" -f "$dockerfile" "${DOCKER_BUILD_CONTEXT}"
STEP 1/14: FROM quay.io/fedora/s2i-core:35
STEP 2/14: ENV HTTPD_VERSION=2.4     NAME=httpd     ARCH=x86_64
--> 22b1587b8c4
STEP 3/14: ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application"     DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, and extensible web server. Apache supports a variety of features, many implemented as compiled modules which extend the core functionality. These can range from server-side programming language support to authentication schemes. Virtual hosting allows one Apache installation to serve many different Web sites."
--> 0cecd45af19
STEP 4/14: LABEL summary="$SUMMARY"       description="$DESCRIPTION"       io.k8s.description="$SUMMARY"       io.k8s.display-name="Apache httpd $HTTPD_VERSION"       io.openshift.expose-services="8080:http,8443:https"       io.openshift.tags="builder,httpd,httpd24"       com.redhat.component="$NAME"       name="fedora/$NAME-24"       version="$HTTPD_VERSION"       usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quya.io/fedora/$NAME-24 sample-server"       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
--> dc63d390f91
STEP 5/14: EXPOSE 8080
--> 7e414ca92cc
STEP 6/14: EXPOSE 8443
--> cd1c5ea2899
STEP 7/14: RUN dnf install -y yum-utils gettext hostname &&     INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security sscg" &&     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS &&     rpm -V $INSTALL_PKGS &&     dnf clean all
Fedora 35 - x86_64                               18 MB/s |  79 MB     00:04
Fedora 35 openh264 (From Cisco) - x86_64        6.3 kB/s | 2.5 kB     00:00
Fedora Modular 35 - x86_64                      1.4 MB/s | 3.3 MB     00:02
Fedora 35 - x86_64 - Updates                    4.6 MB/s |  34 MB     00:07
Fedora Modular 35 - x86_64 - Updates            1.4 MB/s | 3.9 MB     00:02
Last metadata expiration check: 0:00:01 ago on Wed Mar 15 12:57:56 2023.
Package gettext-0.21-8.fc35.x86_64 is already installed.
Dependencies resolved.
================================================================================
 Package                      Arch       Version              Repository   Size
================================================================================
Installing:
 dnf-utils                    noarch     4.3.1-1.fc35         updates      36 k
 hostname                     x86_64     3.23-5.fc35          fedora       27 k
Upgrading:
 dnf                          noarch     4.14.0-1.fc35        updates     471 k
[snipped] 
Complete!
42 files removed
--> cd9e94f1c29
STEP 8/14: ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/     HTTPD_APP_ROOT=${APP_ROOT}     HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf     HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d     HTTPD_TLS_CERT_PATH=/etc/httpd/tls     HTTPD_VAR_RUN=/var/run/httpd     HTTPD_DATA_PATH=/var/www     HTTPD_DATA_ORIG_PATH=/var/www     HTTPD_LOG_PATH=/var/log/httpd
--> 91b56645fa7
STEP 9/14: COPY 2.4/s2i/bin/ $STI_SCRIPTS_PATH
--> cb24dda3cd9
STEP 10/14: COPY 2.4/root /
--> cb44fbe038a
STEP 11/14: RUN /usr/libexec/httpd-prepare && rpm-file-permissions
--> 7ea1c5eabd7
STEP 12/14: USER 1001
--> 9e05ae0e5a6
STEP 13/14: CMD ["/usr/bin/run-httpd"]
--> 53a9d3113c2
STEP 14/14: LABEL "io.openshift.builder-version"="8b02dbc"
COMMIT
--> f0495991e61
f0495991e611bd0062c78bc84698156a061a81fc8302bb12eb8d2713b474c265
```