### PR TITLE
Add ansible-core on C10S and ansible on Fedora and C9S

### DIFF
--- a/plans/c10s.fmf
+++ b/plans/c10s.fmf
@@ -6,7 +6,7 @@ prepare:
     - name: Clone repository and switch to corresponding PR
       how: shell
       script: |
-        dnf install -y git ansible
+        dnf install -y git ansible-core
         git clone $REPO_URL /root/$REPO_NAME
         cd /root/$REPO_NAME
         git fetch origin +refs/pull/*:refs/remotes/origin/pr/*

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -10,15 +10,16 @@
     package_names_all:
       - git
       - make
-      - ansible
       - podman-docker
       - podman
     package_names_c9s:
       - golang-github-cpuguy83-md2man
       - s-nail
+      - ansible
     package_names_c10s:
       - golang-github-cpuguy83-md2man
       - s-nail
+      - ansible-core
     package_names_fedora:
       - acl
       - libseccomp-devel
@@ -26,9 +27,11 @@
       - python3-pip
       - golang-github-cpuguy83-md2man
       - s-nail
+      - ansible
     package_names_gpu_fedora:
       - pciutils
       - hwdata
+      - ansible
     files_to_check_fedora:
       - /etc/containers/nodocker
     files_to_check_c9s:


### PR DESCRIPTION
Add ansible-core on C10S and ansible on Fedora and C9S










































<!-- testing-farm = {"lock":"false","comment-id":"2519833450","data":[{"id":"6718c8ae-127a-4892-b26e-8b1e87711846","name":"RPM check for presence in Fedora with GPU GH100 (H100)","status":"error","outcome":"error","runTime":237.452992,"created":"2024-12-05T10:02:22.569882","updated":"2024-12-05T10:02:22.569892","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6718c8ae-127a-4892-b26e-8b1e87711846\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6718c8ae-127a-4892-b26e-8b1e87711846/pipeline.log\">pipeline</a>"]},{"id":"5a6a1e52-a944-45bd-b4f1-d1d7900d0afd","name":"RPM check for presence in Fedora with GPU GA100 (A100)","status":"error","outcome":"error","runTime":248.678095,"created":"2024-12-05T10:02:21.485340","updated":"2024-12-05T10:02:21.485348","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5a6a1e52-a944-45bd-b4f1-d1d7900d0afd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5a6a1e52-a944-45bd-b4f1-d1d7900d0afd/pipeline.log\">pipeline</a>"]},{"id":"2513ee77-e464-451d-baf0-05c1abf73fba","name":"RPM check for presence in CentOS Stream 10","status":"complete","outcome":"error","runTime":251.005064,"created":"2024-12-05T10:02:21.580146","updated":"2024-12-05T10:02:21.580154","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2513ee77-e464-451d-baf0-05c1abf73fba\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2513ee77-e464-451d-baf0-05c1abf73fba/pipeline.log\">pipeline</a>"]},{"id":"1599cc4d-df61-4a91-9f38-8c959fcf37a0","name":"RPM check for presence in CentOS Stream 9","status":"complete","outcome":"passed","runTime":284.282743,"created":"2024-12-05T10:02:21.511592","updated":"2024-12-05T10:02:21.511600","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1599cc4d-df61-4a91-9f38-8c959fcf37a0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1599cc4d-df61-4a91-9f38-8c959fcf37a0/pipeline.log\">pipeline</a>"]},{"id":"8efef5a8-a183-48c5-9e38-4038810dfe0e","name":"RPM check for presence in Fedora","status":"complete","outcome":"passed","runTime":488.333147,"created":"2024-12-05T10:02:20.610430","updated":"2024-12-05T10:02:20.610437","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8efef5a8-a183-48c5-9e38-4038810dfe0e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8efef5a8-a183-48c5-9e38-4038810dfe0e/pipeline.log\">pipeline</a>"]},{"id":"397517eb-eb8a-4e00-9e1e-9c7127f35c80","name":"RPM check for presence in Fedora with GPU GV100 (Tesla V100)","status":"complete","outcome":"passed","runTime":598.199117,"created":"2024-12-05T10:02:23.732651","updated":"2024-12-05T10:02:23.732659","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/397517eb-eb8a-4e00-9e1e-9c7127f35c80\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/397517eb-eb8a-4e00-9e1e-9c7127f35c80/pipeline.log\">pipeline</a>"]},{"id":"5dc3ce90-2f68-478d-8efc-d0f34e1e849b","name":"RPM check for presence in Fedora with GPU GK210 (Tesla K80)","runTime":646.284851,"created":"2024-12-05T10:02:21.532682","updated":"2024-12-05T10:02:21.532690","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/5dc3ce90-2f68-478d-8efc-d0f34e1e849b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5dc3ce90-2f68-478d-8efc-d0f34e1e849b/pipeline.log\">pipeline</a>"]}]} -->