### PR TITLE
Rename testing plan to centos-stream-10-plan

### DIFF
--- a/.github/workflows/rpm-check.yaml
+++ b/.github/workflows/rpm-check.yaml
@@ -39,12 +39,12 @@ jobs:
             compose: "Fedora-41"
             tmt_hardware: '{"gpu": {"device-name": "GH100 (H100)", "vendor-name": "NVIDIA"}}'
             hardware: "GH100"
-          - os: "c9s"
+          - os: "centos-stream-9-plan"
             context: "CentOS Stream 9"
             compose: "CentOS-Stream-9"
             tmt_hardware: ""
             hardware: ""
-          - os: "c10s"
+          - os: "centos-stream-10-plan"
             context: "CentOS Stream 10"
             compose: "CentOS-Stream-10"
             tmt_hardware: ""
@@ -69,7 +69,6 @@ jobs:
           git_url: "https://github.com/sclorg/sclorg-testing-farm"
           git_ref: "main"
           tf_scope: "public"
-          tmt_context: "trigger=code"
           tmt_plan_regex: "${{ matrix.os }}"
           tmt_hardware: "${{ matrix.tmt_hardware }}"
           update_pull_request_status: true

--- a/plans/c9s.fmf
+++ b/plans/c9s.fmf
@@ -21,11 +21,11 @@ prepare:
         git checkout origin/pr/$PR_NUMBER/head
         git submodule update --init
 
-  - name: Enable repositories and prepare machine for tests
-    how: ansible
-    playbook:
-      - tmt-testing-plan-c9s.yml
-    extra-vars: -vv
+    - name: Enable repositories and prepare machine for tests
+      how: ansible
+      playbook:
+        - tmt-testing-plan-c9s.yml
+      extra-vars: -vv
 
 execute:
     how: tmt

--- a/plans/centos-stream-10-plan.fmf
+++ b/plans/centos-stream-10-plan.fmf
@@ -5,10 +5,10 @@ description: |
 discover:
     how: shell
     tests:
-    - name: '$OS, container: $REPO_NAME, version: $SINGLE_VERSION'
+    - name: Run sclorg-testing-farm tests
       framework: shell
-      test: cd /root/$REPO_NAME && make $TEST_NAME TARGET=$OS SINGLE_VERSION=$SINGLE_VERSION
-      duration: 3h
+      test: cd /root/$REPO_NAME && git status && OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
+      duration: 1h
 
 prepare:
     - name: Clone repository and switch to corresponding PR
@@ -22,10 +22,11 @@ prepare:
         git submodule update --init
 
     - name: Enable repositories and prepare machine for tests
-      how: ansible
-      playbook:
-        - tmt-testing-plan-c10s.yml
-      extra-vars: -vv
+      how: shell
+      script: |
+        cd /root/$REPO_NAME
+        git status
+        ansible-playbook --connection=local --inventory=127.0.0.1, --limit=127.0.0.1 tmt-testing-plan-c10s.yml -vvv
 
 execute:
     how: tmt

--- a/plans/centos-stream-9-plan.fmf
+++ b/plans/centos-stream-9-plan.fmf
@@ -5,10 +5,10 @@ description: |
 discover:
     how: shell
     tests:
-    - name: '$OS, container: $REPO_NAME, version: $SINGLE_VERSION'
+    - name: Run sclorg-testing-farm tests
       framework: shell
-      test: cd /root/$REPO_NAME && make $TEST_NAME TARGET=$OS SINGLE_VERSION=$SINGLE_VERSION
-      duration: 3h
+      test: cd /root/$REPO_NAME && git status && OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
+      duration: 1h
 
 prepare:
     - name: Clone repository and switch to corresponding PR
@@ -21,11 +21,12 @@ prepare:
         git checkout origin/pr/$PR_NUMBER/head
         git submodule update --init
 
-  - name: Enable repositories and prepare machine for tests
-    how: ansible
-    playbook:
-      - tmt-testing-plan-c9s.yml
-    extra-vars: -vv
+    - name: Enable repositories and prepare machine for tests
+      how: shell
+      script: |
+        cd /root/$REPO_NAME
+        git status
+        ansible-playbook --connection=local --inventory=127.0.0.1, --limit=127.0.0.1 tmt-testing-plan-c9s.yml -vvv
 
 execute:
     how: tmt


### PR DESCRIPTION










































<!-- testing-farm = {"lock":"false","comment-id":"2618830477","data":[{"id":"8a81855c-247f-415f-be86-c978f3158357","name":"RPM check for presence in Fedora with GPU GH100 (H100)","status":"error","outcome":"error","runTime":252.484588,"created":"2025-01-28T12:06:51.006137","updated":"2025-01-28T12:06:51.006152","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8a81855c-247f-415f-be86-c978f3158357\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8a81855c-247f-415f-be86-c978f3158357/pipeline.log\">pipeline</a>"]},{"id":"7e47e371-3085-488d-bab5-4ef9cc2de916","name":"RPM check for presence in Fedora with GPU GA100 (A100)","status":"error","outcome":"error","runTime":281.356555,"created":"2025-01-28T12:06:50.558548","updated":"2025-01-28T12:06:50.558559","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7e47e371-3085-488d-bab5-4ef9cc2de916\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7e47e371-3085-488d-bab5-4ef9cc2de916/pipeline.log\">pipeline</a>"]},{"id":"6de485d7-dadc-466b-b27e-12831cd905de","name":"RPM check for presence in CentOS Stream 10","status":"complete","outcome":"passed","runTime":343.813259,"created":"2025-01-28T12:06:49.728100","updated":"2025-01-28T12:06:49.728141","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6de485d7-dadc-466b-b27e-12831cd905de\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6de485d7-dadc-466b-b27e-12831cd905de/pipeline.log\">pipeline</a>"]},{"id":"6f5aa6ee-0ef7-4a76-ad34-af9d01741c9c","name":"RPM check for presence in Fedora","status":"complete","outcome":"passed","runTime":350.719731,"created":"2025-01-28T12:06:48.435895","updated":"2025-01-28T12:06:48.435905","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6f5aa6ee-0ef7-4a76-ad34-af9d01741c9c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6f5aa6ee-0ef7-4a76-ad34-af9d01741c9c/pipeline.log\">pipeline</a>"]},{"id":"80fd1e1c-3292-40cb-b7db-e5632fa6409c","name":"RPM check for presence in CentOS Stream 9","status":"complete","outcome":"passed","runTime":390.716513,"created":"2025-01-28T12:06:48.430360","updated":"2025-01-28T12:06:48.430372","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/80fd1e1c-3292-40cb-b7db-e5632fa6409c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/80fd1e1c-3292-40cb-b7db-e5632fa6409c/pipeline.log\">pipeline</a>"]},{"id":"2a41c1bd-c5d1-4683-9535-da5a5ade1113","name":"RPM check for presence in Fedora with GPU GK210 (Tesla K80)","status":"complete","outcome":"passed","runTime":617.818291,"created":"2025-01-28T12:06:51.801644","updated":"2025-01-28T12:06:51.801651","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2a41c1bd-c5d1-4683-9535-da5a5ade1113\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2a41c1bd-c5d1-4683-9535-da5a5ade1113/pipeline.log\">pipeline</a>"]},{"id":"7131f53d-5ad1-4190-9066-d51d9c76a9e0","name":"RPM check for presence in Fedora with GPU GV100 (Tesla V100)","runTime":894.340804,"created":"2025-01-28T12:06:48.273378","updated":"2025-01-28T12:06:48.273387","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/7131f53d-5ad1-4190-9066-d51d9c76a9e0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7131f53d-5ad1-4190-9066-d51d9c76a9e0/pipeline.log\">pipeline</a>"]}]} -->