### PR TITLE
First draft with enabling image-mode on Testing Farm as GitHub action

### DIFF
--- a/roles/image_mode/tasks/main.yml
+++ b/roles/image_mode/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Install basic tools
+  package:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - git
+    - make
+- name: Install CentOS Stream 9 packages
+  package:
+    name: "{{ item }}"
+    state: latest
+    validate_certs: no
+    disable_gpg_check: true
+  with_items:
+    - podman
+    - podman-docker
+  when: releasever == 9
+
+#- name: Create dir /etc/containers
+#  file:
+#    path: /etc/containers
+#    state: directory
+#    owner: root
+#    group: root
+#  when: releasever > 7
+#
+#- name: ensure file /etc/containers/nodocker exists
+#  file:
+#    path: /etc/containers/nodocker
+#    state: touch
+#    mode: 0644
+#  when: releasever > 7

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -28,6 +28,8 @@
       - golang-github-cpuguy83-md2man
       - s-nail
       - ansible
+    package_names_image_mode_c9s:
+      - podman-bootc
     package_names_gpu_fedora:
       - pciutils
       - hwdata
@@ -51,6 +53,15 @@
           include_tasks: ./tasks/check_file_presents.yml
           loop: "{{ files_to_check_c9s }}"
       when: (os_test is defined) and (os_test == "c9s")
+
+    - block:
+        - name: Check if listed package is installed on Image mode CentOS Stream 9
+          include_tasks: ./tasks/check_rpm_presents.yml
+          loop: "{{ package_names_all + package_names_image_mode_c9s }}"
+        - name: Check if files are present on CentOS Stream 9
+          include_tasks: ./tasks/check_file_presents.yml
+          loop: "{{ files_to_check_c9s }}"
+      when: (os_test is defined) and (os_test == "image-mode-c9s")
 
     - block:
         - name: Check if listed package is installed on CentOS Stream 10

--- a/tmt-testing-plan-image-mode-c9s.yml
+++ b/tmt-testing-plan-image-mode-c9s.yml
@@ -1,0 +1,14 @@
+---
+# This Playbook is used
+# for testing containers on Testing Farm CentOS Stream 9
+
+- hosts: all
+  vars_files:
+    - "group_vars/c9s"
+
+  roles:
+    - role: image_mode
+    #- role: services
+    - role: clone_repos
+  become: true
+  become_user: root


### PR DESCRIPTION
This pull request enables support for Image Mode on C9S.











































<!-- issue-commentator = {"comment-id":"2701162284"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2701141597","data":[{"id":"9a7ab9cf-96e5-4aac-a06f-69a2c0e04aef","name":"RPM check for presence in CentOS Stream 9 Image Mode","status":"error","outcome":"error","runTime":237.113442,"created":"2025-03-17T12:47:24.808067","updated":"2025-03-17T12:47:24.808074","compose":"CentOS-Stream-9-image-mode","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9a7ab9cf-96e5-4aac-a06f-69a2c0e04aef\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9a7ab9cf-96e5-4aac-a06f-69a2c0e04aef/pipeline.log\">pipeline</a>"]},{"id":"fa3a7f0b-4828-46f3-bd4a-f4760ca9db65","name":"RPM check for presence in Fedora","status":"complete","outcome":"error","runTime":309.747736,"created":"2025-03-17T12:47:25.438037","updated":"2025-03-17T12:47:25.438044","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fa3a7f0b-4828-46f3-bd4a-f4760ca9db65\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fa3a7f0b-4828-46f3-bd4a-f4760ca9db65/pipeline.log\">pipeline</a>"]},{"id":"c9997676-7a3d-4d25-b891-07862a483d95","name":"RPM check for presence in Fedora with GPU GH100 (H100)","status":"error","outcome":"error","runTime":288.424532,"created":"2025-03-17T12:47:24.703013","updated":"2025-03-17T12:47:24.703019","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c9997676-7a3d-4d25-b891-07862a483d95\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c9997676-7a3d-4d25-b891-07862a483d95/pipeline.log\">pipeline</a>"]},{"id":"905a6dfd-53f4-437f-b3bf-cf4b76bace4e","name":"RPM check for presence in CentOS Stream 10","status":"complete","outcome":"passed","runTime":357.042319,"created":"2025-03-17T12:47:25.420238","updated":"2025-03-17T12:47:25.420245","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/905a6dfd-53f4-437f-b3bf-cf4b76bace4e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/905a6dfd-53f4-437f-b3bf-cf4b76bace4e/pipeline.log\">pipeline</a>"]},{"id":"d2940f6a-e096-4da4-9947-1e808096ff41","name":"RPM check for presence in CentOS Stream 9","status":"complete","outcome":"passed","runTime":256.716518,"created":"2025-03-17T12:47:25.291482","updated":"2025-03-17T12:47:25.291491","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d2940f6a-e096-4da4-9947-1e808096ff41\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d2940f6a-e096-4da4-9947-1e808096ff41/pipeline.log\">pipeline</a>"]},{"id":"2a72cb23-0f25-4809-94a3-0d0c4f24d576","name":"RPM check for presence in Fedora with GPU GA100 (A100)","status":"error","outcome":"error","runTime":246.012059,"created":"2025-03-14T14:25:36.753454","updated":"2025-03-14T14:25:36.753460","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2a72cb23-0f25-4809-94a3-0d0c4f24d576\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2a72cb23-0f25-4809-94a3-0d0c4f24d576/pipeline.log\">pipeline</a>"]},{"id":"434be9c7-de71-46c9-a603-803722c4e5f9","name":"RPM check for presence in Fedora with GPU GK210 (Tesla K80)","status":"complete","outcome":"error","runTime":399.19114,"created":"2025-03-17T12:47:27.247488","updated":"2025-03-17T12:47:27.247497","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/434be9c7-de71-46c9-a603-803722c4e5f9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/434be9c7-de71-46c9-a603-803722c4e5f9/pipeline.log\">pipeline</a>"]},{"id":"05f801b7-9dcc-4084-b4af-1a56fd3acc5a","name":"RPM check for presence in Fedora with GPU GV100 (Tesla V100)","runTime":684.98414,"created":"2025-03-17T12:47:25.334101","updated":"2025-03-17T12:47:25.334107","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.dev.testing-farm.io/05f801b7-9dcc-4084-b4af-1a56fd3acc5a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/05f801b7-9dcc-4084-b4af-1a56fd3acc5a/pipeline.log\">pipeline</a>"]}]} -->