### PR TITLE
Add plan for Image Mode on CentOS Stream 9

### DIFF
--- a/plans/image-mode-c9s-plan.fmf
+++ b/plans/image-mode-c9s-plan.fmf
@@ -1,0 +1,32 @@
+summary: TMT/TFT plan for running image mode tests on Stream 9
+description: |
+    Running image mode tests on Stream 9
+
+discover:
+    how: shell
+    tests:
+    - name: Run sclorg-testing-farm tests
+      framework: shell
+      test: cd /root/$REPO_NAME && git status && OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
+      duration: 1h
+
+prepare:
+    - name: Clone repository and switch to corresponding PR
+      how: shell
+      script: |
+        dnf install -y git ansible
+        git clone $REPO_URL /root/$REPO_NAME
+        cd /root/$REPO_NAME
+        git fetch origin +refs/pull/*:refs/remotes/origin/pr/*
+        git checkout origin/pr/$PR_NUMBER/head
+        git submodule update --init
+
+    - name: Enable repositories and prepare machine for tests
+      how: shell
+      script: |
+        cd /root/$REPO_NAME
+        git status
+        ansible-playbook --connection=local --inventory=127.0.0.1, --limit=127.0.0.1 tmt-testing-plan-image-mode-c9s.yml -vvv
+
+execute:
+    how: tmt


### PR DESCRIPTION
This pull request adds plan for Image Mode on CentOS Stream 9
