### PR TITLE
Let's install Python3.12 to Fedora, C9S, and C10S

### DIFF
--- a/group_vars/c10s
+++ b/group_vars/c10s
@@ -1,1 +1,2 @@
 releasever: 10
+epel_repo:  https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm

--- a/group_vars/c8s
+++ b/group_vars/c8s
@@ -1,3 +1,0 @@
-releasever: 8
-epel_repo: https://copr.fedorainfracloud.org/coprs/praiskup/distgen/repo/epel-8/praiskup-distgen-epel-8.repo
-yum_dest: /etc/yum.repos.d/distgen-epel-8.repo

--- a/group_vars/c9s
+++ b/group_vars/c9s
@@ -1,1 +1,2 @@
 releasever: 9
+epel_repo:  https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm

--- a/group_vars/centos7
+++ b/group_vars/centos7
@@ -1,1 +1,0 @@
-releasever: 7

--- a/group_vars/fedora
+++ b/group_vars/fedora
@@ -1,1 +1,1 @@
-releasever: 41
+releasever: 42

--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -9,6 +9,7 @@
     - libseccomp-devel
     - postfix
     - acl
+    - fpaste
 
 - name: Install Fedora packages
   package:
@@ -17,25 +18,12 @@
   with_items:
     - golang-github-cpuguy83-md2man
     - openssl
-    - python-pip
+    - python3.12-pip
     - s-nail
     - podman
     - podman-docker
     - pciutils
   when: releasever > 30
-
-- name: Install CentOS Stream 8 packages
-  package:
-    name: "{{ item }}"
-    state: latest
-    validate_certs: no
-    disable_gpg_check: true
-  with_items:
-    - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/g/golang-github-cpuguy83-md2man-2.0.0-4.20210612gitaf8da76.el8.x86_64.rpm
-    - mailx
-    - podman
-    - podman-docker
-  when: releasever == 8
 
 - name: Install CentOS Stream 9 packages
   package:
@@ -48,6 +36,7 @@
     - s-nail
     - podman
     - podman-docker
+    - python3.12-pip
   when: releasever == 9
 
 - name: Install CentOS Stream 10 packages
@@ -61,8 +50,8 @@
     - s-nail
     - podman
     - podman-docker
+    - python3.12-pip
   when: releasever == 10
-
 
 - name: Create dir /etc/containers
   file:

--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -18,7 +18,9 @@
   with_items:
     - golang-github-cpuguy83-md2man
     - openssl
-    - python3.12-pip
+    - python3.12
+    - python3-pytest
+    - python3-pip
     - s-nail
     - podman
     - podman-docker
@@ -36,7 +38,9 @@
     - s-nail
     - podman
     - podman-docker
-    - python3.12-pip
+    - python3.12
+    - python3-pytest
+    - python3-pip
   when: releasever == 9
 
 - name: Install CentOS Stream 10 packages
@@ -50,7 +54,9 @@
     - s-nail
     - podman
     - podman-docker
-    - python3.12-pip
+    - python3.12
+    - python3-pytest
+    - python3-pip
   when: releasever == 10
 
 - name: Create dir /etc/containers

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -12,22 +12,25 @@
       - make
       - podman-docker
       - podman
+      - fpaste
     package_names_c9s:
       - golang-github-cpuguy83-md2man
       - s-nail
       - ansible
+      - python3.12-pip
     package_names_c10s:
       - golang-github-cpuguy83-md2man
       - s-nail
       - ansible-core
+      - python3.12-pip
     package_names_fedora:
       - acl
       - libseccomp-devel
       - openssl
-      - python3-pip
       - golang-github-cpuguy83-md2man
       - s-nail
       - ansible
+      - python3.12-pip
     package_names_image_mode_c9s:
       - podman-bootc
     package_names_gpu_fedora:

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -17,12 +17,16 @@
       - golang-github-cpuguy83-md2man
       - s-nail
       - ansible
-      - python3.12-pip
+      - python3.12
+      - python3-pytest
+      - python3-pip
     package_names_c10s:
       - golang-github-cpuguy83-md2man
       - s-nail
       - ansible-core
-      - python3.12-pip
+      - python3.12
+      - python3-pytest
+      - python3-pip
     package_names_fedora:
       - acl
       - libseccomp-devel
@@ -30,7 +34,9 @@
       - golang-github-cpuguy83-md2man
       - s-nail
       - ansible
-      - python3.12-pip
+      - python3.12
+      - python3-pytest
+      - python3-pip
     package_names_image_mode_c9s:
       - podman-bootc
     package_names_gpu_fedora:


### PR DESCRIPTION
We need python3.12 in order to run PyTests in Container repos.

<!-- testing-farm = {"lock":"false","comment-id":"3227300266","data":[{"id":"9183dfd9-eac4-455e-b08e-d4aa8c6e6ed7","name":"RPM check for presence in CentOS Stream 9 Image Mode","status":"complete","outcome":"error","runTime":318.600556,"created":"2025-08-27T10:43:05.092992","updated":"2025-08-27T10:43:05.092998","compose":"CentOS-Stream-9-image-mode","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9183dfd9-eac4-455e-b08e-d4aa8c6e6ed7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9183dfd9-eac4-455e-b08e-d4aa8c6e6ed7/pipeline.log\">pipeline</a>"]},{"id":"0c44d350-6862-4731-9f4c-5d534d0809b7","name":"RPM check for presence in Fedora with GPU GA100 (A100)","status":"error","outcome":"error","runTime":270.887932,"created":"2025-08-27T10:43:04.818885","updated":"2025-08-27T10:43:04.818894","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0c44d350-6862-4731-9f4c-5d534d0809b7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0c44d350-6862-4731-9f4c-5d534d0809b7/pipeline.log\">pipeline</a>"]},{"id":"75ccafab-3d46-4692-a91e-40d5da3cb9cb","name":"RPM check for presence in Fedora with GPU GH100 (H100)","status":"error","outcome":"error","runTime":2128.25246,"created":"2025-08-27T10:43:04.935353","updated":"2025-08-27T10:43:04.935360","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/75ccafab-3d46-4692-a91e-40d5da3cb9cb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/75ccafab-3d46-4692-a91e-40d5da3cb9cb/pipeline.log\">pipeline</a>"]},{"id":"66f144de-6e56-4e3f-ae93-3599cde8713d","name":"RPM check for presence in Fedora with GPU GV100 (Tesla V100)","status":"complete","outcome":"passed","runTime":3786.549851,"created":"2025-08-27T10:03:56.961205","updated":"2025-08-27T10:03:56.961212","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/66f144de-6e56-4e3f-ae93-3599cde8713d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/66f144de-6e56-4e3f-ae93-3599cde8713d/pipeline.log\">pipeline</a>"]},{"id":"40858c71-5914-4955-b4bf-962359d93e96","name":"RPM check for presence in CentOS Stream 9","status":"complete","outcome":"passed","runTime":428.784977,"created":"2025-08-27T10:43:03.808887","updated":"2025-08-27T10:43:03.808897","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/40858c71-5914-4955-b4bf-962359d93e96\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/40858c71-5914-4955-b4bf-962359d93e96/pipeline.log\">pipeline</a>"]},{"id":"ad04d32b-4384-4627-96bb-3ead616b164b","name":"RPM check for presence in CentOS Stream 10","status":"complete","outcome":"passed","runTime":365.372112,"created":"2025-08-27T10:43:03.841364","updated":"2025-08-27T10:43:03.841371","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ad04d32b-4384-4627-96bb-3ead616b164b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ad04d32b-4384-4627-96bb-3ead616b164b/pipeline.log\">pipeline</a>"]},{"id":"af972d55-40a6-44e1-864c-b82f53af0c49","name":"RPM check for presence in Fedora","status":"complete","outcome":"error","runTime":1158.21391,"created":"2025-08-27T10:19:14.058783","updated":"2025-08-27T10:19:14.058789","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/af972d55-40a6-44e1-864c-b82f53af0c49\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/af972d55-40a6-44e1-864c-b82f53af0c49/pipeline.log\">pipeline</a>"]},{"id":"91b0849a-8687-4af5-b60f-a4bda77d2eda","name":"RPM check for presence in Fedora with GPU GK210 (Tesla K80)","runTime":14472.56149,"created":"2025-08-27T08:29:44.369577","updated":"2025-08-27T08:29:44.369586","compose":"Fedora-41","arch":"x86_64","infrastructureFailure":true,"status":"error","outcome":"error","results":["<a href=\"https://artifacts.dev.testing-farm.io/91b0849a-8687-4af5-b60f-a4bda77d2eda\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/91b0849a-8687-4af5-b60f-a4bda77d2eda/pipeline.log\">pipeline</a>"]}]} -->