### PR TITLE
Remove fpaste for TMT plans.

### DIFF
--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -13,7 +13,6 @@
     - libseccomp-devel
     - postfix
     - acl
-    - fpaste
     - gcc-c++
 
 - name: Install Fedora packages

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -12,7 +12,6 @@
       - make
       - podman-docker
       - podman
-      - fpaste
     package_names_c9s:
       - golang-github-cpuguy83-md2man
       - s-nail


### PR DESCRIPTION
We do not use logdetective in Public ranch
fpaste is not needed. 

LogDetective analysis is used only for RHEL land

<!-- testing-farm = {"lock":"false","comment-id":"3232700073","data":[{"id":"fb188d9d-60e8-442a-80a0-e1ade7798d27","name":"RPM check for presence in CentOS Stream 10","status":"complete","outcome":"passed","runTime":224.323034,"created":"2025-08-28T09:22:45.394156","updated":"2025-08-28T09:22:45.394163","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fb188d9d-60e8-442a-80a0-e1ade7798d27\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fb188d9d-60e8-442a-80a0-e1ade7798d27/pipeline.log\">pipeline</a>"]},{"id":"98d3d0f0-11fb-4f33-aacb-f39ff105c458","name":"RPM check for presence in Fedora","status":"complete","outcome":"passed","runTime":253.629214,"created":"2025-08-28T09:22:47.911353","updated":"2025-08-28T09:22:47.911362","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/98d3d0f0-11fb-4f33-aacb-f39ff105c458\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/98d3d0f0-11fb-4f33-aacb-f39ff105c458/pipeline.log\">pipeline</a>"]},{"id":"7963c257-fb12-4769-b831-5cee74e6b0a0","name":"RPM check for presence in Fedora with GPU GA100 (A100)","status":"error","outcome":"error","runTime":265.137148,"created":"2025-08-28T09:22:45.033226","updated":"2025-08-28T09:22:45.033235","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":true,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7963c257-fb12-4769-b831-5cee74e6b0a0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7963c257-fb12-4769-b831-5cee74e6b0a0/pipeline.log\">pipeline</a>"]},{"id":"f93ef2f2-27df-4526-9147-be6498d61e5d","name":"RPM check for presence in Fedora with GPU GV100 (Tesla V100)","status":"complete","outcome":"passed","runTime":289.375773,"created":"2025-08-28T09:22:48.247974","updated":"2025-08-28T09:22:48.247980","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f93ef2f2-27df-4526-9147-be6498d61e5d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f93ef2f2-27df-4526-9147-be6498d61e5d/pipeline.log\">pipeline</a>"]},{"id":"d76c64f6-a3ee-411b-a8e0-59567fdd5f0f","name":"RPM check for presence in CentOS Stream 9 Image Mode","status":"complete","outcome":"error","runTime":308.54716,"created":"2025-08-28T09:24:00.757500","updated":"2025-08-28T09:24:00.757506","compose":"CentOS-Stream-9-image-mode","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d76c64f6-a3ee-411b-a8e0-59567fdd5f0f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d76c64f6-a3ee-411b-a8e0-59567fdd5f0f/pipeline.log\">pipeline</a>"]},{"id":"e4c7c68d-bd05-4592-baeb-30d81214c819","name":"RPM check for presence in Fedora with GPU GK210 (Tesla K80)","runTime":14487.815151,"created":"2025-08-28T09:22:45.128523","updated":"2025-08-28T09:22:45.128531","compose":"Fedora-42","arch":"x86_64","infrastructureFailure":true,"status":"error","outcome":"error","results":["<a href=\"https://artifacts.dev.testing-farm.io/e4c7c68d-bd05-4592-baeb-30d81214c819\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e4c7c68d-bd05-4592-baeb-30d81214c819/pipeline.log\">pipeline</a>"]}]} -->