### PR TITLE
Remove go-md2man package

### DIFF
--- a/.github/workflows/rpm-check.yaml
+++ b/.github/workflows/rpm-check.yaml
@@ -17,18 +17,12 @@ jobs:
           - os: "fedora"
             context: "Fedora"
             compose: "Fedora-43"
-            tmt_hardware: ""
-            hardware: ""
           - os: "centos-stream-9-plan"
             context: "CentOS Stream 9"
             compose: "CentOS-Stream-9"
-            tmt_hardware: ""
-            hardware: ""
           - os: "centos-stream-10-plan"
             context: "CentOS Stream 10"
             compose: "CentOS-Stream-10"
-            tmt_hardware: ""
-            hardware: ""
 
     if: |
       github.event.issue.pull_request
@@ -50,10 +44,9 @@ jobs:
           git_ref: "main"
           tf_scope: "public"
           tmt_plan_regex: "${{ matrix.os }}"
-          tmt_hardware: "${{ matrix.tmt_hardware }}"
           tmt_context: "trigger=code"          
           update_pull_request_status: true
           create_issue_comment: true          
           pull_request_status_name: "RPM check for presence in ${{ matrix.context }}"
-          variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=${{ matrix.os }}${{ matrix.hardware }}"
+          variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=${{ matrix.os }}"
           compose: ${{ matrix.compose }}

--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -21,7 +21,6 @@
     name: "{{ item }}"
     state: latest
   with_items:
-    - golang-github-cpuguy83-md2man
     - openssl
     - s-nail
     - podman
@@ -39,7 +38,6 @@
     validate_certs: no
     disable_gpg_check: true
   with_items:
-    - https://kojihub.stream.centos.org/kojifiles/packages/golang-github-cpuguy83-md2man/2.0.0/16.gitaf8da76.el9/x86_64/golang-github-cpuguy83-md2man-2.0.0-16.gitaf8da76.el9.x86_64.rpm
     - s-nail
     - podman
     - podman-docker
@@ -55,7 +53,6 @@
     validate_certs: no
     disable_gpg_check: true
   with_items:
-    - https://kojihub.stream.centos.org/kojifiles/vol/koji02/packages/golang-github-cpuguy83-md2man/2.0.3/3.el10/x86_64/golang-github-cpuguy83-md2man-2.0.3-3.el10.x86_64.rpm
     - s-nail
     - podman
     - podman-docker

--- a/tmt-sclorg-testing-plan.yml
+++ b/tmt-sclorg-testing-plan.yml
@@ -14,14 +14,12 @@
       - podman
       - jq
     package_names_c9s:
-      - golang-github-cpuguy83-md2man
       - s-nail
       - ansible
       - python3.12
       - python3.12-pytest
       - python3.12-pip
     package_names_c10s:
-      - golang-github-cpuguy83-md2man
       - s-nail
       - ansible-core
       - python3
@@ -31,7 +29,6 @@
       - acl
       - libseccomp-devel
       - openssl
-      - golang-github-cpuguy83-md2man
       - s-nail
       - ansible
       - python3


### PR DESCRIPTION
Remove go-md2man package.
We do not need it at all.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a specific golang-related package from installation lists for Fedora, CentOS Stream 9, and CentOS Stream 10 to reduce dependency footprint.
  * Simplified CI/PR automation by removing hardware matrix entries and related variables, streamlining workflow configuration and automation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4073818808","data":[{"id":"e5a8a5cc-ad34-4772-86c9-0419011cddda","name":"RPM check for presence in Fedora","status":"complete","outcome":"failed","runTime":411.549588,"created":"2026-03-17T10:06:42.355335","updated":"2026-03-17T10:06:42.355341","compose":"Fedora-43","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e5a8a5cc-ad34-4772-86c9-0419011cddda\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e5a8a5cc-ad34-4772-86c9-0419011cddda/pipeline.log\">pipeline</a>"]},{"id":"8ea19dfd-5fae-4f1e-9fa2-189cfb068659","name":"RPM check for presence in CentOS Stream 9","status":"complete","outcome":"passed","runTime":513.854521,"created":"2026-03-17T10:06:42.519508","updated":"2026-03-17T10:06:42.519516","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8ea19dfd-5fae-4f1e-9fa2-189cfb068659\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8ea19dfd-5fae-4f1e-9fa2-189cfb068659/pipeline.log\">pipeline</a>"]},{"id":"9f1745f9-176c-4c0c-b885-9465ea9d78b9","name":"RPM check for presence in CentOS Stream 10","runTime":584.030993,"created":"2026-03-17T10:07:02.312070","updated":"2026-03-17T10:07:02.312078","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/9f1745f9-176c-4c0c-b885-9465ea9d78b9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9f1745f9-176c-4c0c-b885-9465ea9d78b9/pipeline.log\">pipeline</a>"]}]} -->