### PR TITLE
Enable building and testing container on C11S host.

### DIFF
--- a/group_vars/c11s
+++ b/group_vars/c11s
@@ -1,0 +1,2 @@
+releasever: 11
+epel_repo:  https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm

--- a/plans/c11s.fmf
+++ b/plans/c11s.fmf
@@ -1,0 +1,31 @@
+summary: TMT/TFT plan for running container tests on CentOS Stream 11
+description: |
+    Run container tests on CentOS Stream 11
+
+discover:
+    how: shell
+    tests:
+    - name: '$OS, container: $REPO_NAME, version: $SINGLE_VERSION'
+      framework: shell
+      test: cd /root/$REPO_NAME && make $TEST_NAME TARGET=$OS SINGLE_VERSION=$SINGLE_VERSION
+      duration: 3h
+
+prepare:
+    - name: Clone repository and switch to corresponding PR
+      how: shell
+      script: |
+        dnf install -y git ansible-core
+        git clone $REPO_URL /root/$REPO_NAME
+        cd /root/$REPO_NAME
+        git fetch origin +refs/pull/*:refs/remotes/origin/pr/*
+        git checkout origin/pr/$PR_NUMBER/head
+        git submodule update --init
+
+    - name: Enable repositories and prepare machine for tests
+      how: ansible
+      playbook:
+        - tmt-testing-plan-c11s.yml
+      extra-vars: -vv
+
+execute:
+    how: tmt

--- a/plans/fedora.fmf
+++ b/plans/fedora.fmf
@@ -48,6 +48,7 @@ execute:
       - name: Enable repositories and prepare machine for tests
         how: shell
         script: |
+          export TEST_NAME=test
           cd /root/$REPO_NAME
           git status
           ansible-playbook --connection=local --inventory=127.0.0.1, --limit=127.0.0.1 tmt-testing-plan-fedora.yml -vvv
@@ -56,5 +57,5 @@ execute:
         tests:
         - name: 'Tests for OS: $OS, repo: $REPO_NAME'
           framework: shell
-          test: cd /root/$REPO_NAME && git status && OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
+          test: cd /root/$REPO_NAME && git status && TEST_NAME=test OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
           duration: 1h

--- a/plans/nightly/nightly-c11s.fmf
+++ b/plans/nightly/nightly-c11s.fmf
@@ -1,0 +1,20 @@
+summary: TMT/TFT plan for running container nightly tests
+description: |
+    Run nightly container tests on CentOS Stream 11
+
+discover:
+    how: shell
+    tests:
+    - name: Run nightly tests
+      framework: shell
+      test: cd /root/ci-scripts && ./daily-tests/daily_tests/daily_scl_tests.sh $OS $TEST
+      duration: 7h
+
+prepare:
+    - name: Enable repositories and prepare machine for tests
+      how: ansible
+      playbook:
+        - tmt-testing-plan-c11s.yml
+
+execute:
+    how: tmt

--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Enable CentOS-Stream-CRB
   action: shell dnf config-manager --set-enabled crb
-  when: releasever == 9 or releasever == 10
+  when: releasever < 30
 
 - name: Install basic tools
   package:
@@ -46,7 +46,7 @@
     - python3.12-pip
   when: releasever == 9
 
-- name: Install CentOS Stream 10 packages
+- name: Install CentOS Stream 10 and CentOS Stream 11 packages
   package:
     name: "{{ item }}"
     state: latest
@@ -59,7 +59,7 @@
     - python3.12
     - python3.12-pytest
     - python3.12-pip
-  when: releasever == 10
+  when: releasever == 10 or releasever == 11
 
 - name: Create dir /etc/containers
   file:
@@ -80,7 +80,7 @@
   pip:
     name: git+https://github.com/sclorg/container-ci-suite
     executable: pip3.12
-  when: releasever == 9 or releasever == 10
+  when: releasever < 30
 
 - name: Install container-ci-suite for tests
   pip:

--- a/roles/image_mode/tasks/main.yml
+++ b/roles/image_mode/tasks/main.yml
@@ -15,19 +15,4 @@
   with_items:
     - podman
     - podman-docker
-  when: releasever == 9
-
-#- name: Create dir /etc/containers
-#  file:
-#    path: /etc/containers
-#    state: directory
-#    owner: root
-#    group: root
-#  when: releasever > 7
-#
-#- name: ensure file /etc/containers/nodocker exists
-#  file:
-#    path: /etc/containers/nodocker
-#    state: touch
-#    mode: 0644
-#  when: releasever > 7
+  when: releasever < 30

--- a/tmt-testing-plan-c11s.yml
+++ b/tmt-testing-plan-c11s.yml
@@ -1,0 +1,14 @@
+---
+# This Playbook is used
+# for testing containers on Testing Farm CentOS Stream 11
+
+- hosts: all
+  vars_files:
+    - "group_vars/c11s"
+
+  roles:
+    - role: common_tools
+    - role: services
+    - role: clone_repos
+  become: true
+  become_user: root


### PR DESCRIPTION
As CentOS Stream 11 is not present yet,
let's use CentOS Stream 10 for now and as soon as
it will be present, than switch it to CentOS Stream 11

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CentOS Stream 11 support for automated testing pipelines

* **Chores**
  * Updated test infrastructure configurations to support CentOS Stream 11
  * Added nightly test execution capability for CentOS Stream 11
  * Expanded package installation compatibility across multiple system versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4243460715","data":[{"id":"26dc3ac7-8119-4a86-9206-4e240ea5f555","name":"RPM check for presence in CentOS Stream 11","runTime":522.04953,"created":"2026-04-14T12:10:10.870629","updated":"2026-04-14T12:10:10.870638","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/26dc3ac7-8119-4a86-9206-4e240ea5f555\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/26dc3ac7-8119-4a86-9206-4e240ea5f555/pipeline.log\">pipeline</a>"]},{"id":"a8675c9e-ab98-4211-96a1-9625ee4ae3bc","name":"RPM check for presence in Fedora","status":"complete","outcome":"passed","runTime":336.910904,"created":"2026-04-14T12:10:12.527709","updated":"2026-04-14T12:10:12.527716","compose":"Fedora-43","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a8675c9e-ab98-4211-96a1-9625ee4ae3bc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a8675c9e-ab98-4211-96a1-9625ee4ae3bc/pipeline.log\">pipeline</a>"]},{"id":"d7b2f12b-b0ab-402e-9d9e-9df1cac7bd8e","name":"RPM check for presence in CentOS Stream 10","status":"complete","outcome":"passed","runTime":542.044927,"created":"2026-04-14T12:10:10.924419","updated":"2026-04-14T12:10:10.924427","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d7b2f12b-b0ab-402e-9d9e-9df1cac7bd8e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d7b2f12b-b0ab-402e-9d9e-9df1cac7bd8e/pipeline.log\">pipeline</a>"]},{"id":"c72da28f-1cb0-4fe8-b49a-832fde139e58","name":"RPM check for presence in CentOS Stream 9","status":"complete","outcome":"passed","runTime":526.043341,"created":"2026-04-14T12:10:10.908444","updated":"2026-04-14T12:10:10.908451","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c72da28f-1cb0-4fe8-b49a-832fde139e58\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c72da28f-1cb0-4fe8-b49a-832fde139e58/pipeline.log\">pipeline</a>"]}]} -->