### PR TITLE
Enable building and testing container on C11S host.

### DIFF
--- a/group_vars/c11s
+++ b/group_vars/c11s
@@ -1,0 +1,2 @@
+releasever: 11
+epel_repo:  https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm

--- a/plans/c11s.fmf
+++ b/plans/c11s.fmf
@@ -1,0 +1,31 @@
+summary: TMT/TFT plan for running container tests on CentOS Stream 11
+description: |
+    Run container tests on CentOS Stream 11
+
+discover:
+    how: shell
+    tests:
+    - name: '$OS, container: $REPO_NAME, version: $SINGLE_VERSION'
+      framework: shell
+      test: cd /root/$REPO_NAME && make $TEST_NAME TARGET=$OS SINGLE_VERSION=$SINGLE_VERSION
+      duration: 3h
+
+prepare:
+    - name: Clone repository and switch to corresponding PR
+      how: shell
+      script: |
+        dnf install -y git ansible-core
+        git clone $REPO_URL /root/$REPO_NAME
+        cd /root/$REPO_NAME
+        git fetch origin +refs/pull/*:refs/remotes/origin/pr/*
+        git checkout origin/pr/$PR_NUMBER/head
+        git submodule update --init
+
+    - name: Enable repositories and prepare machine for tests
+      how: ansible
+      playbook:
+        - tmt-testing-plan-c11s.yml
+      extra-vars: -vv
+
+execute:
+    how: tmt

--- a/plans/centos-stream-11-plan.fmf
+++ b/plans/centos-stream-11-plan.fmf
@@ -1,0 +1,32 @@
+summary: TMT/TFT plan for running container tests on CentOS Stream 11
+description: |
+    Run container tests on CentOS Stream 11
+
+discover:
+    how: shell
+    tests:
+    - name: Run sclorg-testing-farm tests
+      framework: shell
+      test: cd /root/$REPO_NAME && git status && OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
+      duration: 1h
+
+prepare:
+    - name: Clone repository and switch to corresponding PR
+      how: shell
+      script: |
+        dnf install -y git ansible-core
+        git clone $REPO_URL /root/$REPO_NAME
+        cd /root/$REPO_NAME
+        git fetch origin +refs/pull/*:refs/remotes/origin/pr/*
+        git checkout origin/pr/$PR_NUMBER/head
+        git submodule update --init
+
+    - name: Enable repositories and prepare machine for tests
+      how: shell
+      script: |
+        cd /root/$REPO_NAME
+        git status
+        ansible-playbook --connection=local --inventory=127.0.0.1, --limit=127.0.0.1 tmt-testing-plan-c11s.yml -vvv
+
+execute:
+    how: tmt

--- a/plans/fedora.fmf
+++ b/plans/fedora.fmf
@@ -48,6 +48,7 @@ execute:
       - name: Enable repositories and prepare machine for tests
         how: shell
         script: |
+          export TEST_NAME=test
           cd /root/$REPO_NAME
           git status
           ansible-playbook --connection=local --inventory=127.0.0.1, --limit=127.0.0.1 tmt-testing-plan-fedora.yml -vvv
@@ -56,5 +57,5 @@ execute:
         tests:
         - name: 'Tests for OS: $OS, repo: $REPO_NAME'
           framework: shell
-          test: cd /root/$REPO_NAME && git status && OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
+          test: cd /root/$REPO_NAME && git status && TEST_NAME=test OS="$OS" ansible-playbook tmt-sclorg-testing-plan.yml
           duration: 1h

--- a/plans/nightly/nightly-c11s.fmf
+++ b/plans/nightly/nightly-c11s.fmf
@@ -1,0 +1,20 @@
+summary: TMT/TFT plan for running container nightly tests
+description: |
+    Run nightly container tests on CentOS Stream 11
+
+discover:
+    how: shell
+    tests:
+    - name: Run nightly tests
+      framework: shell
+      test: cd /root/ci-scripts && ./daily-tests/daily_tests/daily_scl_tests.sh $OS $TEST
+      duration: 7h
+
+prepare:
+    - name: Enable repositories and prepare machine for tests
+      how: ansible
+      playbook:
+        - tmt-testing-plan-c11s.yml
+
+execute:
+    how: tmt

--- a/roles/common_tools/tasks/main.yml
+++ b/roles/common_tools/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Enable CentOS-Stream-CRB
   action: shell dnf config-manager --set-enabled crb
-  when: releasever == 9 or releasever == 10
+  when: releasever < 30
 
 - name: Install basic tools
   package:
@@ -46,7 +46,7 @@
     - python3.12-pip
   when: releasever == 9
 
-- name: Install CentOS Stream 10 packages
+- name: Install CentOS Stream 10 and CentOS Stream 11 packages
   package:
     name: "{{ item }}"
     state: latest
@@ -59,7 +59,7 @@
     - python3.12
     - python3.12-pytest
     - python3.12-pip
-  when: releasever == 10
+  when: releasever == 10 or releasever == 11
 
 - name: Create dir /etc/containers
   file:
@@ -80,7 +80,7 @@
   pip:
     name: git+https://github.com/sclorg/container-ci-suite
     executable: pip3.12
-  when: releasever == 9 or releasever == 10
+  when: releasever < 30
 
 - name: Install container-ci-suite for tests
   pip:

--- a/roles/image_mode/tasks/main.yml
+++ b/roles/image_mode/tasks/main.yml
@@ -15,19 +15,4 @@
   with_items:
     - podman
     - podman-docker
-  when: releasever == 9
-
-#- name: Create dir /etc/containers
-#  file:
-#    path: /etc/containers
-#    state: directory
-#    owner: root
-#    group: root
-#  when: releasever > 7
-#
-#- name: ensure file /etc/containers/nodocker exists
-#  file:
-#    path: /etc/containers/nodocker
-#    state: touch
-#    mode: 0644
-#  when: releasever > 7
+  when: releasever < 30

--- a/tmt-testing-plan-c11s.yml
+++ b/tmt-testing-plan-c11s.yml
@@ -1,0 +1,14 @@
+---
+# This Playbook is used
+# for testing containers on Testing Farm CentOS Stream 11
+
+- hosts: all
+  vars_files:
+    - "group_vars/c11s"
+
+  roles:
+    - role: common_tools
+    - role: services
+    - role: clone_repos
+  become: true
+  become_user: root


### PR DESCRIPTION
As CentOS Stream 11 is not present yet,
let's use CentOS Stream 10 for now and as soon as
it will be present, than switch it to CentOS Stream 11

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
